### PR TITLE
Updating Resources for new DSCResource.Common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue in Reverse DSC that affected collection query capture
 when collection queries have quotes.
 
+- Fixed an issue causing some tests to unexpectedly fail with a newer
+version of DSCResource.Common
+
 ## [3.0.0] - 2022-01-03
 
 ### Added

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
       - job: Package_Module
         displayName: 'Package Module'
         pool:
-          vmImage: 'ubuntu 18.04'
+          vmImage: 'ubuntu 20.04'
         steps:
           - pwsh: |
               dotnet tool install --global GitVersion.Tool
@@ -157,7 +157,7 @@ stages:
         displayName: 'Publish Code Coverage'
         dependsOn: Test_Unit
         pool:
-          vmImage: 'ubuntu 18.04'
+          vmImage: 'ubuntu 20.04'
         timeoutInMinutes: 0
         steps:
           - pwsh: |
@@ -207,7 +207,7 @@ stages:
       - job: Deploy_Module
         displayName: 'Deploy Module'
         pool:
-          vmImage: 'ubuntu 18.04'
+          vmImage: 'ubuntu 20.04'
         steps:
           - task: DownloadBuildArtifacts@0
             displayName: 'Download Build Artifact'

--- a/source/DSCResources/DSC_CMDistributionPoint/DSC_CMDistributionPoint.psm1
+++ b/source/DSCResources/DSC_CMDistributionPoint/DSC_CMDistributionPoint.psm1
@@ -592,7 +592,7 @@ function Test-TargetResource
                                 'EnableBranchCache','EnableLedbat')
             }
 
-            $result = Test-DscParameterState @testParams -Verbose
+            $result = Test-DscParameterState @testParams -Verbose -TurnOffTypeChecking
 
             if ($BoundaryGroups)
             {

--- a/source/DSCResources/DSC_CMPxeDistributionPoint/DSC_CMPxeDistributionPoint.psm1
+++ b/source/DSCResources/DSC_CMPxeDistributionPoint/DSC_CMPxeDistributionPoint.psm1
@@ -331,7 +331,7 @@ function Test-TargetResource
                 'PxeServerResponseDelaySec','UserDeviceAffinity')
         }
 
-        $returnValue = Test-DscParameterState @testParams -Verbose
+        $returnValue = Test-DscParameterState @testParams -Verbose -TurnOffTypeChecking
 
         if ((-not [string]::IsNullOrEmpty($PxePassword)) -and ([string]::IsNullOrEmpty($state.PxePassword)))
         {

--- a/source/DSCResources/DSC_CMReportingServicePoint/DSC_CMReportingServicePoint.psm1
+++ b/source/DSCResources/DSC_CMReportingServicePoint/DSC_CMReportingServicePoint.psm1
@@ -321,7 +321,7 @@ function Test-TargetResource
                 ValuesToCheck = ('DatabaseName','DatabaseServerName','Username','FolderName','ReportServerInstance')
             }
 
-            $result = Test-DscParameterState @testParams -Verbose
+            $result = Test-DscParameterState @testParams -Verbose -TurnOffTypeChecking
 
             if ($FolderName -or $ReportServerInstance)
             {

--- a/source/DSCResources/DSC_CMSiteSystemServer/DSC_CMSiteSystemServer.psm1
+++ b/source/DSCResources/DSC_CMSiteSystemServer/DSC_CMSiteSystemServer.psm1
@@ -454,7 +454,7 @@ function Test-TargetResource
                 ValuesToCheck = @('PublicFqdn','FdmOperation','UseSiteServerAccount','AccountName')
             }
 
-            $result = Test-DscParameterState @testParams -Verbose
+            $result = Test-DscParameterState @testParams -Verbose -TurnOffTypeChecking
 
             $proxyCheck = @('EnableProxy','ProxyServerName','ProxyServerPort','ProxyAccessAccount')
 


### PR DESCRIPTION

#### Pull Request (PR) description
This PR adds the -TurnOffTypeChecking parameter to any Test-DscParameterState commands within the Test-TargetResource method for the CMDistribnutionPoint, CMPxeDistributionPoint, CMReportingServicePoint, and CMSiteSystemServer resources.

This parameter was added to address a minor issue with some pester tests.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/configmgrcbdsc/111)
<!-- Reviewable:end -->
